### PR TITLE
Pom/code cleanup. SSTableRowMapper warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,11 +170,6 @@
             <artifactId>log4j-over-slf4j</artifactId>
             <version>1.7.4</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.4</version>
-        </dependency>
 
         <!-- Internal dependencies -->
 
@@ -215,6 +210,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.1.2</version>
                 <executions>
@@ -230,6 +226,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/com/knewton/mapreduce/SSTableColumnMapper.java
+++ b/src/main/java/com/knewton/mapreduce/SSTableColumnMapper.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce;
 
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
 /**
  * Abstract mapper class that takes in a row key as its key and a column as its value. Used in
  * conjunction with {@link SSTableColumnRecordReader}
- * 
+ *
  * @param <K2>
  *            Out key
  * @param <V2>
@@ -69,7 +69,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
     /**
      * This should be defined in the child class to output any key/value pairs that need to go to a
      * reducer.
-     * 
+     *
      * @param key
      * @param value
      * @param context
@@ -80,7 +80,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
             Context context) throws IOException, InterruptedException;
 
     /**
-     * 
+     *
      * @return True if deleted columns will be skipped false otherwise.
      */
     public boolean isSkipDeletedColumns() {
@@ -88,7 +88,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
     }
 
     /**
-     * 
+     *
      * @param skipDeletedColumns
      */
     public void setSkipDeletedColumns(boolean skipDeletedColumns) {
@@ -99,7 +99,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
      * Any modifications to the column name <code>ByteBuffer</code> or the column value
      * <code>ByteBuffer</code> needs to be rewinded. Make sure you know what you're doing if you
      * call this.
-     * 
+     *
      * @return The current cassandra column.
      */
     protected IColumn getIColumn() {
@@ -109,7 +109,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
     /**
      * Any modifications to this row key bytebuffer should be rewinded. Make sure you know what
      * you're doing if you call this.
-     * 
+     *
      * @return The original <code>ByteBuffer</code> representing the row key.
      */
     protected ByteBuffer getRowKey() {
@@ -119,7 +119,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
     /**
      * Get the mapper specific key that would make the sstable row key into something more
      * meaningful.
-     * 
+     *
      * @param key
      * @param context
      * @return Mapper key of type <code>K1</code>
@@ -129,7 +129,7 @@ public abstract class SSTableColumnMapper<K1, V1, K2 extends WritableComparable,
     /**
      * Get the mapper specific value that would make an SSTable column into something more
      * meaningful.
-     * 
+     *
      * @param iColumn
      * @param context
      * @return Mapper value of type <code>V1</code>

--- a/src/main/java/com/knewton/mapreduce/SSTableColumnRecordReader.java
+++ b/src/main/java/com/knewton/mapreduce/SSTableColumnRecordReader.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce;
 
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
 /**
  * Record reader for sstables that calls map with the key being the sstable row key and the value a
  * single column.
- * 
+ *
  */
 public class SSTableColumnRecordReader extends
         SSTableRecordReader<ByteBuffer, OnDiskAtom> {
@@ -32,7 +32,7 @@ public class SSTableColumnRecordReader extends
 
     /**
      * Gets the next key and value in the table.
-     * 
+     *
      * @return True if there's more keys. False otherwise.
      * @throws IOException
      * @throws InterruptedException

--- a/src/main/java/com/knewton/mapreduce/SSTableRecordReader.java
+++ b/src/main/java/com/knewton/mapreduce/SSTableRecordReader.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce;
 
@@ -53,7 +53,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * row record reader ({@link SSTableRowRecordReader}), passing an entire row as a key/value pair and
  * a column record reader ({@link SSTableColumnRecordReader}) passing individual columns as values.
  * Used in conjunction with {@link SSTableInputFormat}
- * 
+ *
  * @param <K>
  * @param <V>
  */
@@ -91,7 +91,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Close all opened resources and delete temporary local files used for reading the data.
-     * 
+     *
      * @throws IOException
      */
     @Override
@@ -110,7 +110,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Returns the value of the current key.
-     * 
+     *
      * @return The current key in the data table.
      * @throws IOException
      * @throws InterruptedException
@@ -122,7 +122,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Returns an iterator of the columns under the <code>currentKey<code>.
-     * 
+     *
      * @return SSTableIdentityIterator Column iterator.
      * @throws IOException
      * @throws InterruptedException
@@ -135,7 +135,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Method for calculating the progress made so far from this record reader.
-     * 
+     *
      * @return A value from 0 to 1 indicating the progress so far.
      * @throws IOException
      * @throws InterruptedException
@@ -147,7 +147,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Performs all the necessary actions to initialize and prepare this record reader.
-     * 
+     *
      * @param inputSplit
      * @param context
      * @throws IOException
@@ -190,7 +190,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Mainly here for testing.
-     * 
+     *
      * @param tableReader
      */
     private void setTableScanner(SSTableReader tableReader) {
@@ -204,7 +204,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Mainly here for unit tests.
-     * 
+     *
      * @return SSTable descriptor.
      */
     public Descriptor getDescriptor() {
@@ -213,7 +213,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Moves all the minimum required tables for the table reader to work to local disk.
-     * 
+     *
      * @param split
      *            The table to work on.
      * @param context
@@ -277,7 +277,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
      * Decompresses input files that were snappy compressed before opening them with the sstable
      * reader.It writes a new decompressed file with the same name as the compressed one. The old
      * one gets deleted.
-     * 
+     *
      * @param localTablePath
      * @param context
      * @throws IOException
@@ -320,7 +320,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Creates a column family type from <code>conf</code>
-     * 
+     *
      * @param conf
      * @return A column family type. Simple or Super.
      */
@@ -330,7 +330,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Get an instance of a partitioner.
-     * 
+     *
      * @param conf
      * @param parameterName
      *            The name of the parameter to get from conf and instantiate.
@@ -351,7 +351,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Get an instance of a comparator used for comparing keys in the sstables.
-     * 
+     *
      * @param conf
      * @param parameterName
      *            The parameter name from the configuration object.
@@ -375,7 +375,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
     /**
      * Minimum required parameters needed to be set for this type of record reader. Many other
      * parameters are inferred from the table filenames. Fail fast if conf parameters are missing.
-     * 
+     *
      * @param conf
      */
     private void validateConfiguration(Configuration conf) {
@@ -387,7 +387,7 @@ public abstract class SSTableRecordReader<K, V> extends RecordReader<K, V> {
 
     /**
      * Increments the number of keys read from the data table.
-     * 
+     *
      * @param val
      *            The value to be added to <code>keysRead<code>.
      */

--- a/src/main/java/com/knewton/mapreduce/SSTableRowMapper.java
+++ b/src/main/java/com/knewton/mapreduce/SSTableRowMapper.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce;
 
@@ -24,17 +24,16 @@ import java.nio.ByteBuffer;
 
 /**
  * Abstract mapper class that takes in a row key as its key and a column as its value. Used in
- * conjunction with {@linkSSTableRowRecordReader}
- * 
+ * conjunction with {@link SSTableRowRecordReader}
+ *
  * @author Giannis Neokleous
- * 
+ *
  * @param <K1>
  * @param <V1>
  * @param <K2>
  * @param <V2>
  */
-@SuppressWarnings("rawtypes")
-public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable, V2 extends Writable>
+public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable<?>, V2 extends Writable>
         extends Mapper<ByteBuffer, SSTableIdentityIterator, K2, V2> {
 
     private ByteBuffer key;
@@ -62,7 +61,7 @@ public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable, V2
     /**
      * This should be defined in the child class to output any key/value pairs that need to go to a
      * reducer.
-     * 
+     *
      * @param key
      * @param value
      * @param context
@@ -76,7 +75,7 @@ public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable, V2
      * Any modifications to the row key <code>ByteBuffer</code> or the row iterator
      * <code>SSTableIdentityIterator</code> needs to be rewinded. Make sure you know what you're
      * doing if you call this.
-     * 
+     *
      * @return The current Cassandra row iterator.
      */
     protected SSTableIdentityIterator getRowIterator() {
@@ -86,7 +85,7 @@ public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable, V2
     /**
      * Any modifications to this row key <code>ByteBuffer</code> should be rewinded. Make sure you
      * know what you're doing if you call this.
-     * 
+     *
      * @return The original <code>ByteBuffer</code> representing the row key.
      */
     protected ByteBuffer getRowKey() {
@@ -96,7 +95,7 @@ public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable, V2
     /**
      * Get the mapper specific key that would make the sstable row key into something more
      * meaningful.
-     * 
+     *
      * @param key
      * @param context
      * @return
@@ -105,7 +104,7 @@ public abstract class SSTableRowMapper<K1, V1, K2 extends WritableComparable, V2
 
     /**
      * Get the mapper specific value that would make a row iterator into something more meaningful.
-     * 
+     *
      * @param rowIter
      * @param context
      * @return

--- a/src/main/java/com/knewton/mapreduce/SSTableRowRecordReader.java
+++ b/src/main/java/com/knewton/mapreduce/SSTableRowRecordReader.java
@@ -1,33 +1,34 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce;
 
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
  * Abstract mapper class that takes in a row key as its key and a column as its value.
- * 
+ *
  */
 public class SSTableRowRecordReader extends SSTableRecordReader<ByteBuffer,
         SSTableIdentityIterator> {
 
     /**
      * Gets the next key and value in the table.
-     * 
+     *
      * @return True if there's more keys. False otherwise.
      * @throws IOException
      * @throws InterruptedException

--- a/src/main/java/com/knewton/mapreduce/StudentEventAbstractMapper.java
+++ b/src/main/java/com/knewton/mapreduce/StudentEventAbstractMapper.java
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce;
 
+import com.knewton.mapreduce.util.CounterConstants;
 import com.knewton.thrift.StudentEvent;
 import com.knewton.thrift.StudentEventData;
-import com.knewton.mapreduce.util.CounterConstants;
 
 import org.apache.cassandra.db.IColumn;
 import org.apache.hadoop.conf.Configuration;
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 /**
  * Abstract mapper that converts a cassandra column to a student event and a cassandra row key to a
  * student id.
- * 
+ *
  * @param <K>
  * @param <V>
  */
@@ -50,7 +50,7 @@ import javax.annotation.Nullable;
 public abstract class StudentEventAbstractMapper<K extends WritableComparable, V extends Writable>
         extends SSTableColumnMapper<Long, StudentEvent, K, V> {
 
-    private TDeserializer decoder;
+    private final TDeserializer decoder;
     private Interval timeRange;
     private static final Logger LOG =
             LoggerFactory.getLogger(StudentEventAbstractMapper.class);
@@ -108,7 +108,7 @@ public abstract class StudentEventAbstractMapper<K extends WritableComparable, V
 
     /**
      * Make a student event out of a column in cassandra.
-     * 
+     *
      * @param value
      * @param context
      * @return
@@ -144,7 +144,7 @@ public abstract class StudentEventAbstractMapper<K extends WritableComparable, V
 
     /**
      * Checks to see if the event is in the desired time range.
-     * 
+     *
      * @param eventId
      * @param context
      * @return
@@ -164,7 +164,7 @@ public abstract class StudentEventAbstractMapper<K extends WritableComparable, V
      * Sets up a DateTime interval for excluding student events. When start time is not set then it
      * defaults to the beginning of time. If end date is not specified then it defaults to
      * "the end of time".
-     * 
+     *
      * @param conf
      */
     private void setupTimeRange(Configuration conf) {

--- a/src/main/java/com/knewton/mapreduce/example/SSTableMRExample.java
+++ b/src/main/java/com/knewton/mapreduce/example/SSTableMRExample.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.example;
 
@@ -38,10 +38,10 @@ import java.net.URL;
 /**
  * Example job for reading data from SSTables. This example uses the StudentEvents column family
  * that stores serialized StudentEvent objects defined in a thrift specification under the thrift
- * source directory. Sample SSTables can be generated with {@link WriteSampleSSTable}.
- * 
+ * source directory. Sample SSTables can be generated with WriteSampleSSTable in the test resources.
+ *
  * @author Giannis Neokleous
- * 
+ *
  */
 public class SSTableMRExample {
 
@@ -121,7 +121,7 @@ public class SSTableMRExample {
 
     /**
      * Prints usage information for running this program with all the options.
-     * 
+     *
      * @param options
      */
     private static void printUsage(Options options) {

--- a/src/main/java/com/knewton/mapreduce/example/StudentEventMapper.java
+++ b/src/main/java/com/knewton/mapreduce/example/StudentEventMapper.java
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.example;
 
-import com.knewton.thrift.StudentEvent;
 import com.knewton.mapreduce.StudentEventAbstractMapper;
 import com.knewton.mapreduce.io.StudentEventWritable;
+import com.knewton.thrift.StudentEvent;
 
 import org.apache.hadoop.io.LongWritable;
 

--- a/src/main/java/com/knewton/mapreduce/example/StudentEventReducer.java
+++ b/src/main/java/com/knewton/mapreduce/example/StudentEventReducer.java
@@ -1,22 +1,22 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.example;
 
+import com.knewton.mapreduce.io.StudentEventWritable;
 import com.knewton.thrift.StudentEvent;
 import com.knewton.thrift.StudentEventData;
-import com.knewton.mapreduce.io.StudentEventWritable;
 
 import com.google.common.collect.Lists;
 
@@ -25,15 +25,14 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Reducer;
 
-import java.io.*;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 public class StudentEventReducer extends Reducer<LongWritable,
         StudentEventWritable, LongWritable, Text> {
 
-    public static final String STUDENT_INTERACTIONS_COUNT =
-            "STUDENT_INTERACTIONS";
+    public static final String STUDENT_INTERACTIONS_COUNT = "STUDENT_INTERACTIONS";
     protected static char DELIMITER;
 
     /**
@@ -76,7 +75,7 @@ public class StudentEventReducer extends Reducer<LongWritable,
 
     /**
      * Helper method for writing the student event in CSV style.
-     * 
+     *
      * @param key
      * @param studentEventWritable
      * @param context

--- a/src/main/java/com/knewton/mapreduce/io/SSTableColumnInputFormat.java
+++ b/src/main/java/com/knewton/mapreduce/io/SSTableColumnInputFormat.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.io;
 
@@ -26,13 +26,13 @@ import java.nio.ByteBuffer;
 
 /**
  * Input format that instantiates an sstable column record reader.
- * 
+ *
  */
 public class SSTableColumnInputFormat extends SSTableInputFormat<ByteBuffer, OnDiskAtom> {
 
     /**
      * Create a new record reader for this <code>split<code>.
-     * 
+     *
      * @param split
      * @param context
      * @throws IOException

--- a/src/main/java/com/knewton/mapreduce/io/SSTableInputFormat.java
+++ b/src/main/java/com/knewton/mapreduce/io/SSTableInputFormat.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.io;
 
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * Input format for reading cassandra SSTables. When given an input directory, it expands all
  * subdirectories and identifies SSTable data files that can be used as input.
- * 
+ *
  * @param <K>
  * @param <V>
  */
@@ -50,7 +50,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * Make SSTables not splittable for now so send the entire file to each record writer.
-     * 
+     *
      * @param context
      *            The job context
      * @param path
@@ -63,7 +63,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * Expands all directories passed as input and keeps only valid data tables.
-     * 
+     *
      * @param job
      * @return A list of all the data tables found under the input directories.
      * @throws IOException
@@ -101,7 +101,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * Comparator class name for columns.
-     * 
+     *
      * @param name
      * @param job
      */
@@ -112,7 +112,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * This is not required if the column family type is standard.
-     * 
+     *
      * @param name
      * @param job
      */
@@ -123,7 +123,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * Partitioner for decorating keys.
-     * 
+     *
      * @param name
      * @param job
      */
@@ -134,7 +134,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * Column family type needs to be set if the column family type is Super.
-     * 
+     *
      * @param name
      * @param job
      */
@@ -146,7 +146,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
     /**
      * Set the name of the column family to read. This is optional. If not set all the datatables
      * under the given input directory will be collected and processed.
-     * 
+     *
      * @param name
      * @param job
      */
@@ -157,7 +157,7 @@ public abstract class SSTableInputFormat<K, V> extends FileInputFormat<K, V> {
 
     /**
      * Custom path filter for SSTables.
-     * 
+     *
      */
     public static class DataTablePathFilter implements PathFilter {
 

--- a/src/main/java/com/knewton/mapreduce/io/SSTableRowInputFormat.java
+++ b/src/main/java/com/knewton/mapreduce/io/SSTableRowInputFormat.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.io;
 
@@ -26,14 +26,14 @@ import java.nio.ByteBuffer;
 
 /**
  * Input format that instantiates an sstable row record reader.
- * 
+ *
  */
 public class SSTableRowInputFormat extends SSTableInputFormat<ByteBuffer,
         SSTableIdentityIterator> {
 
     /**
      * Create a new record reader for this <code>split<code>.
-     * 
+     *
      * @param split
      * @param context
      * @throws IOException

--- a/src/main/java/com/knewton/mapreduce/io/StudentEventWritable.java
+++ b/src/main/java/com/knewton/mapreduce/io/StudentEventWritable.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.io;
 
@@ -29,13 +29,13 @@ import java.util.Comparator;
 
 /**
  * Wrapper class for StudentEvents that is Hadoop writable so that it can be used in the reducer.
- * 
+ *
  */
 public class StudentEventWritable implements Writable, Cloneable {
 
     private StudentEvent studentEvent;
-    private TSerializer serializer;
-    private TDeserializer deserializer;
+    private final TSerializer serializer;
+    private final TDeserializer deserializer;
     private long timestamp;
 
     public StudentEventWritable() {
@@ -97,6 +97,7 @@ public class StudentEventWritable implements Writable, Cloneable {
         return timestamp;
     }
 
+    @Override
     public StudentEventWritable clone() {
         StudentEventWritable sew = new StudentEventWritable(
                 new StudentEvent(studentEvent), this.timestamp);
@@ -119,7 +120,7 @@ public class StudentEventWritable implements Writable, Cloneable {
 
     /**
      * Comparator for StudentEventWritables based on the timestamp.
-     * 
+     *
      */
     public static class StudentEventTimestampComparator implements
             Comparator<StudentEventWritable> {
@@ -134,7 +135,7 @@ public class StudentEventWritable implements Writable, Cloneable {
 
     /**
      * Comparator for StudentEventWritables based on the student event id.
-     * 
+     *
      */
     public static class StudentEventIdComparator implements
             Comparator<StudentEventWritable> {

--- a/src/main/java/com/knewton/mapreduce/io/sstable/BackwardsCompatibleDescriptor.java
+++ b/src/main/java/com/knewton/mapreduce/io/sstable/BackwardsCompatibleDescriptor.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.io.sstable;
 
@@ -18,7 +18,6 @@ import com.google.common.base.Splitter;
 
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
-import org.apache.cassandra.io.sstable.Descriptor.Version;
 import org.apache.cassandra.utils.Pair;
 import org.apache.commons.lang3.StringUtils;
 
@@ -35,9 +34,9 @@ import static org.apache.cassandra.io.sstable.Component.separator;
  * &lt;cfname&gt;-[tmp-][&lt;version&gt;-]&lt;gen&gt;-&lt;component&gt; <br/>
  * Cassandra 1.1-1.2 file format:
  * &lt;ksname&gt;-&lt;cfname&gt;-[tmp-][&lt;version&gt;-]&lt;gen&gt;-&lt;component&gt;
- * 
+ *
  * @author giannis
- * 
+ *
  */
 public class BackwardsCompatibleDescriptor extends Descriptor {
 
@@ -70,7 +69,7 @@ public class BackwardsCompatibleDescriptor extends Descriptor {
     /**
      * Implementation of {@link Descriptor#fromFilename(String)} that is backwards compatible with
      * older sstables
-     * 
+     *
      * @param filename
      * @return A descriptor for the sstable
      */
@@ -82,7 +81,7 @@ public class BackwardsCompatibleDescriptor extends Descriptor {
     /**
      * Implementation of {@link Descriptor#fromFilename(File, String)} that is backwards compatible
      * with older sstables
-     * 
+     *
      * @param directory
      * @param name
      * @return A descriptor for the sstable

--- a/src/main/java/com/knewton/mapreduce/util/CassandraColumnUtils.java
+++ b/src/main/java/com/knewton/mapreduce/util/CassandraColumnUtils.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.util;
 
@@ -22,7 +22,7 @@ public class CassandraColumnUtils {
 
     /**
      * Helper method for figuring out if a row has super columns.
-     * 
+     *
      * @param row
      * @return True if row contains super columns false otherwise.
      */
@@ -32,7 +32,7 @@ public class CassandraColumnUtils {
 
     /**
      * Helper method for figuring out if a column is an instance of a <code>SuperColumn</code>
-     * 
+     *
      * @param column
      * @return True if super column false otherwise.
      */

--- a/src/main/java/com/knewton/mapreduce/util/CounterConstants.java
+++ b/src/main/java/com/knewton/mapreduce/util/CounterConstants.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.util;
 

--- a/src/main/java/com/knewton/mapreduce/util/MREnvironment.java
+++ b/src/main/java/com/knewton/mapreduce/util/MREnvironment.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.util;
 
@@ -39,7 +39,7 @@ public enum MREnvironment {
 
     /**
      * Gets an enum type from a string value.
-     * 
+     *
      * @param strVal
      * @return
      */

--- a/src/main/java/com/knewton/mapreduce/util/SerializationUtils.java
+++ b/src/main/java/com/knewton/mapreduce/util/SerializationUtils.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013 Knewton
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  */
 package com.knewton.mapreduce.util;
 


### PR DESCRIPTION
- Removed unnecessary properties from pom.xml
- Don't halt on coverage error
- Removing a warning from SSTableRowMapper
- Removing extra whitespace and rearranging imports.
